### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Ports:
 | -e     | `EXTERN_LISTENPORT`  | `8686`                         | Listen port for remote boosters on the external side of this booster. | N        |
 | -e     | `INTERN_LISTENPORT`  | `8688`                         | Listen port for applications on the internal side of this booster. | N        |
 | -e     | `PROPDIR`            | `./propdir`                    | Name of property directory containing  booster profiles.     | N        |
+| -e     | `BOOSTER_LICENSE`    | not set                        | A booster license key                                        | N        |
+| -e     | `BOOSTER_MACADDRESS` | not set                        | The MAC address the license key is assigned to. Note that using this variable requires that the container has `NET_ADMIN` capabiity | N |
 
 ### Parent mode
 
@@ -81,9 +83,19 @@ The address is only required for a parent booster.
 
 Pitch Booster requires MAC address based license to run. This requires that the container is started with a specific MAC address and that the license key is either mounted into the container or already present (injected) inside the container image.
 
-With the MAC address based license the Booster container must be started with the `--mac-address` option, providing a MAC address value that corresponds with the license key. Not all overlay networks support a user defined MAC address. Overlay networks under Docker generally support user defined MAC addresses, but overlay networks under Kubernetes do not. An experimental workaround to this limitation is described in [Run Booster with Docker In Docker](docs/DockerInDocker.md).
+With the MAC address based license the Booster container must be started with the `--mac-address` option, providing a MAC address value that corresponds with the license key. Not all overlay networks support a user defined MAC address. Overlay networks under Docker generally support user defined MAC addresses, but overlay networks under Kubernetes do not. If the container is run in Kubernetes, a workaround based on environment variables exists. An earlier, experimental workaround to this limitation is described in [Run Booster with Docker In Docker](docs/DockerInDocker.md).
 
 The following applies to overlay networks that support a user defined MAC address.
+
+### Mount license key through environment variables
+
+The Pitch Booster image takes the environment variables `BOOSTER_LICENSE` and `BOOSTER_MACADDRESS` as inputs. These can be used to mount a license into the container at run-time.
+
+If the `BOOSTER_MACADDRESS` environment variable is set, the Booster container will create a virtual network interface with the given MAC address. This is useful for containers running in Kubernetes environments, where the MAC address of the main network interface can not be set explicitly. Note that the container requires the `NET_ADMIN` capability in order for this to work.
+
+The `BOOSTER_LICENSE` environment variable can be used to insert a license string into the Booster container. The container will then attempt to activate this license. If the license is bound to a particular MAC addres, this MAC address should be added to the container through either the `--mac-address` option of Docker, or by setting the `BOOSTER_MACADDRESS` environment variable of the container.
+
+Once the container has initialised a virtual network interface and/or attempted to activate a license key, it will continue to run normally.
 
 ### Mount license key
 

--- a/docker/context/Dockerfile
+++ b/docker/context/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir -p ${BOOSTER_HOME}
 #########################
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y net-tools dnsutils
+RUN apt-get update && apt-get install -y net-tools dnsutils iproute2
 
 # Set the BOOSTER_HOME
 ENV BOOSTER_HOME=/usr/local/PitchBooster

--- a/docker/context/start.sh
+++ b/docker/context/start.sh
@@ -80,7 +80,7 @@ fi
 
 if [ -n "$BOOSTER_LICENSE" ]; then
 	echo "BOOSTER: Run license activator with $BOOSTER_LICENSE"
-	/usr/local/PitchBooster/BoosterLicenseActivator $BOOSTER_LICENSE
+	echo $BOOSTER_LICENSE | /usr/local/PitchBooster/BoosterLicenseActivator
 fi
 
 if [ -z "${ISCHILD}" ] || [ "${ISCHILD}" = "0" ]; then

--- a/docker/context/start.sh
+++ b/docker/context/start.sh
@@ -78,7 +78,7 @@ if [ -n "$BOOSTER_MACADDRESS" ]; then
 	ip link set eth0.1 up
 fi
 
-if [ -n "$BOOSTER_LICENSE"]
+if [ -n "$BOOSTER_LICENSE"]; then
 	echo "BOOSTER: Run license activator with $BOOSTER_LICENSE"
 	/usr/local/PitchBooster/BoosterLicenseActivator $BOOSTER_LICENSE
 fi

--- a/docker/context/start.sh
+++ b/docker/context/start.sh
@@ -47,6 +47,9 @@ echo "CHILDID"=$CHILDID
 echo "CHILDNAME"=$CHILDNAME
 echo "CHILDPROFILE"=$CHILDPROFILE
 
+echo "BOOSTER_MACADDRESS"=$BOOSTER_MACADDRESS
+echo "BOOSTER_LICENSE"=$BOOSTER_LICENSE
+
 # A POSIX variable
 OPTIND=1         # Reset in case getopts has been used previously in the shell.
 
@@ -67,6 +70,17 @@ if [ "$license" != "" ]; then
 	echo "Booster: run license activator with '$license'"
 	echo $license | /usr/local/PitchBooster/BoosterLicenseActivator
 	exit
+fi
+
+if [ -n "$BOOSTER_MACADDRESS" ]; then
+	echo "BOOSTER: Set MAC address to $BOOSTER_MACADDRESS"
+	ip link add link eth0 address $BOOSTER_MACADDRESS eth0.1 type macvlan
+	ip link set eth0.1 up
+fi
+
+if [ -n "$BOOSTER_LICENSE"]
+	echo "BOOSTER: Run license activator with $BOOSTER_LICENSE"
+	/usr/local/PitchBooster/BoosterLicenseActivator $BOOSTER_LICENSE
 fi
 
 if [ -z "${ISCHILD}" ] || [ "${ISCHILD}" = "0" ]; then

--- a/docker/context/start.sh
+++ b/docker/context/start.sh
@@ -78,7 +78,7 @@ if [ -n "$BOOSTER_MACADDRESS" ]; then
 	ip link set eth0.1 up
 fi
 
-if [ -n "$BOOSTER_LICENSE"]; then
+if [ -n "$BOOSTER_LICENSE" ]; then
 	echo "BOOSTER: Run license activator with $BOOSTER_LICENSE"
 	/usr/local/PitchBooster/BoosterLicenseActivator $BOOSTER_LICENSE
 fi


### PR DESCRIPTION
Tested the new BOOSTER_MACADDRESS and BOOSTER_LICENSE environment variables. They now seem to work, even if another container is running on the same pod using the same MAC address: the ip link add command returns a File exists answer, but it does not crash the script, and continues happily. This seems good enough to me